### PR TITLE
Todd/add context free data

### DIFF
--- a/EosioSwiftSoftkeySignatureProvider/EosioSoftkeySignatureProvider.swift
+++ b/EosioSwiftSoftkeySignatureProvider/EosioSoftkeySignatureProvider.swift
@@ -62,6 +62,10 @@ public final class EosioSoftkeySignatureProvider: EosioSignatureProviderProtocol
     ///   - request: An `EosioTransactionSignatureRequest` struct (as defined in the `EosioSwift` library).
     ///   - completion: Calls the completion with an `EosioTransactionSignatureResponse` struct (as defined in the `EosioSwift` library).
     public func signTransaction(request: EosioTransactionSignatureRequest, completion: @escaping (EosioTransactionSignatureResponse) -> Void) {
+        print("1")
+        print(request)
+        print(request.publicKeys)
+        print("-------")
         var response = EosioTransactionSignatureResponse()
         do {
             var signatures = [String]()
@@ -76,8 +80,8 @@ public final class EosioSoftkeySignatureProvider: EosioSignatureProviderProtocol
                 objc_sync_exit(lock)
                 let chainIdData = try Data(hex: request.chainId)
                 var contextFreeDataHash = Data(repeating: 0, count: 32)
-                if request.contextFreeData.count > 0 {
-                    contextFreeDataHash = request.contextFreeData.sha256
+                if request.serializedContextFreeData.count > 0 {
+                    contextFreeDataHash = request.serializedContextFreeData.sha256
                 }
                 let data = try EosioEccSign.signWithK1(publicKey: key.uncompressedPublicKey, privateKey: key.privateKey, data: chainIdData + request.serializedTransaction + contextFreeDataHash)
                 signatures.append(data.toEosioK1Signature)
@@ -85,6 +89,7 @@ public final class EosioSoftkeySignatureProvider: EosioSignatureProviderProtocol
             var signedTransaction = EosioTransactionSignatureResponse.SignedTransaction()
             signedTransaction.signatures = signatures
             signedTransaction.serializedTransaction = request.serializedTransaction
+            signedTransaction.serializedContextFreeData = request.serializedContextFreeData
             response.signedTransaction = signedTransaction
             completion(response)
         } catch {

--- a/EosioSwiftSoftkeySignatureProvider/EosioSoftkeySignatureProvider.swift
+++ b/EosioSwiftSoftkeySignatureProvider/EosioSoftkeySignatureProvider.swift
@@ -75,8 +75,11 @@ public final class EosioSoftkeySignatureProvider: EosioSignatureProviderProtocol
                 }
                 objc_sync_exit(lock)
                 let chainIdData = try Data(hex: request.chainId)
-                let zeros = Data(repeating: 0, count: 32)
-                let data = try EosioEccSign.signWithK1(publicKey: key.uncompressedPublicKey, privateKey: key.privateKey, data: chainIdData + request.serializedTransaction + zeros)
+                var contextFreeDataHash = Data(repeating: 0, count: 32)
+                if request.contextFreeData.count > 0 {
+                    contextFreeDataHash = request.contextFreeData.sha256
+                }
+                let data = try EosioEccSign.signWithK1(publicKey: key.uncompressedPublicKey, privateKey: key.privateKey, data: chainIdData + request.serializedTransaction + contextFreeDataHash)
                 signatures.append(data.toEosioK1Signature)
             }
             var signedTransaction = EosioTransactionSignatureResponse.SignedTransaction()

--- a/EosioSwiftSoftkeySignatureProvider/EosioSoftkeySignatureProvider.swift
+++ b/EosioSwiftSoftkeySignatureProvider/EosioSoftkeySignatureProvider.swift
@@ -62,10 +62,6 @@ public final class EosioSoftkeySignatureProvider: EosioSignatureProviderProtocol
     ///   - request: An `EosioTransactionSignatureRequest` struct (as defined in the `EosioSwift` library).
     ///   - completion: Calls the completion with an `EosioTransactionSignatureResponse` struct (as defined in the `EosioSwift` library).
     public func signTransaction(request: EosioTransactionSignatureRequest, completion: @escaping (EosioTransactionSignatureResponse) -> Void) {
-        print("1")
-        print(request)
-        print(request.publicKeys)
-        print("-------")
         var response = EosioTransactionSignatureResponse()
         do {
             var signatures = [String]()


### PR DESCRIPTION
Use the serializedContextFreeData in the message to be signed.
Return the serializedContextFreeData in the response.